### PR TITLE
Add lint checks to the build script.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+**/*.spec.js
+codeExample.js
+dist
+examples

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,371 @@
+{
+    "root": true,
+    "parser": "babel-eslint",
+    "plugins": ["import", "flowtype", "jsx-a11y", "react"],
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es6": true,
+        "jest": true,
+        "node": true
+    },
+    "parserOptions": {
+        "ecmaVersion": 6,
+        "sourceType": "module",
+        "ecmaFeatures": {
+            "jsx": true,
+            "generators": true,
+            "experimentalObjectRestSpread": true
+        }
+    },
+    "rules": {
+        "array-callback-return": "warn",
+        "default-case": [
+            "warn",
+            {
+                "commentPattern": "^no default$"
+            }
+        ],
+        "dot-location": ["warn", "property"],
+        "eqeqeq": ["warn", "allow-null"],
+        "new-parens": "warn",
+        "no-array-constructor": "warn",
+        "no-caller": "warn",
+        "no-cond-assign": ["warn", "except-parens"],
+        "no-const-assign": "warn",
+        "no-control-regex": "warn",
+        "no-delete-var": "warn",
+        "no-dupe-args": "warn",
+        "no-dupe-class-members": "warn",
+        "no-dupe-keys": "warn",
+        "no-duplicate-case": "warn",
+        "no-empty-character-class": "warn",
+        "no-empty-pattern": "warn",
+        "no-eval": "warn",
+        "no-ex-assign": "warn",
+        "no-extend-native": "warn",
+        "no-extra-bind": "warn",
+        "no-extra-label": "warn",
+        "no-fallthrough": "warn",
+        "no-func-assign": "warn",
+        "no-implied-eval": "warn",
+        "no-invalid-regexp": "warn",
+        "no-iterator": "warn",
+        "no-label-var": "warn",
+        "no-labels": [
+            "warn",
+            {
+                "allowLoop": true,
+                "allowSwitch": false
+            }
+        ],
+        "no-lone-blocks": "warn",
+        "no-loop-func": "warn",
+        "no-mixed-operators": [
+            "warn",
+            {
+                "groups": [
+                    ["&", "|", "^", "~", "<<", ">>", ">>>"],
+                    ["==", "!=", "===", "!==", ">", ">=", "<", "<="],
+                    ["&&", "||"],
+                    ["in", "instanceof"]
+                ],
+                "allowSamePrecedence": false
+            }
+        ],
+        "no-multi-str": "warn",
+        "no-native-reassign": "warn",
+        "no-negated-in-lhs": "warn",
+        "no-new-func": "warn",
+        "no-new-object": "warn",
+        "no-new-symbol": "warn",
+        "no-new-wrappers": "warn",
+        "no-obj-calls": "warn",
+        "no-octal": "warn",
+        "no-octal-escape": "warn",
+        "no-redeclare": "warn",
+        "no-regex-spaces": "warn",
+        "no-restricted-syntax": ["warn", "WithStatement"],
+        "no-script-url": "warn",
+        "no-self-assign": "warn",
+        "no-self-compare": "warn",
+        "no-sequences": "warn",
+        "no-shadow-restricted-names": "warn",
+        "no-sparse-arrays": "warn",
+        "no-template-curly-in-string": "warn",
+        "no-this-before-super": "warn",
+        "no-throw-literal": "warn",
+        "no-undef": "error",
+        "no-restricted-globals": [
+            "error",
+            "addEventListener",
+            "blur",
+            "close",
+            "closed",
+            "confirm",
+            "defaultStatus",
+            "defaultstatus",
+            "event",
+            "external",
+            "find",
+            "focus",
+            "frameElement",
+            "frames",
+            "history",
+            "innerHeight",
+            "innerWidth",
+            "length",
+            "location",
+            "locationbar",
+            "menubar",
+            "moveBy",
+            "moveTo",
+            "name",
+            "onblur",
+            "onerror",
+            "onfocus",
+            "onload",
+            "onresize",
+            "onunload",
+            "open",
+            "opener",
+            "opera",
+            "outerHeight",
+            "outerWidth",
+            "pageXOffset",
+            "pageYOffset",
+            "parent",
+            "print",
+            "removeEventListener",
+            "resizeBy",
+            "resizeTo",
+            "screen",
+            "screenLeft",
+            "screenTop",
+            "screenX",
+            "screenY",
+            "scroll",
+            "scrollbars",
+            "scrollBy",
+            "scrollTo",
+            "scrollX",
+            "scrollY",
+            "self",
+            "status",
+            "statusbar",
+            "stop",
+            "toolbar",
+            "top"
+        ],
+        "no-unexpected-multiline": "warn",
+        "no-unreachable": "warn",
+        "no-unused-expressions": [
+            "error",
+            {
+                "allowShortCircuit": true,
+                "allowTernary": true,
+                "allowTaggedTemplates": true
+            }
+        ],
+        "no-unused-labels": "warn",
+        "no-unused-vars": [
+            "warn",
+            {
+                "args": "none",
+                "ignoreRestSiblings": true
+            }
+        ],
+        "no-use-before-define": [
+            "warn",
+            {
+                "functions": false,
+                "classes": false,
+                "variables": false
+            }
+        ],
+        "no-useless-computed-key": "warn",
+        "no-useless-concat": "warn",
+        "no-useless-constructor": "warn",
+        "no-useless-escape": "warn",
+        "no-useless-rename": [
+            "warn",
+            {
+                "ignoreDestructuring": false,
+                "ignoreImport": false,
+                "ignoreExport": false
+            }
+        ],
+        "no-with": "warn",
+        "no-whitespace-before-property": "warn",
+        "require-yield": "warn",
+        "rest-spread-spacing": ["warn", "never"],
+        "strict": ["warn", "never"],
+        "unicode-bom": ["warn", "never"],
+        "use-isnan": "warn",
+        "valid-typeof": "warn",
+        "no-restricted-properties": [
+            "error",
+            {
+                "object": "require",
+                "property": "ensure",
+                "message":
+                    "Please use import() instead. More info: https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#code-splitting"
+            },
+            {
+                "object": "System",
+                "property": "import",
+                "message":
+                    "Please use import() instead. More info: https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#code-splitting"
+            }
+        ],
+        "getter-return": "warn",
+        "import/first": "error",
+        "import/no-amd": "error",
+        "import/no-webpack-loader-syntax": "error",
+        "react/forbid-foreign-prop-types": [
+            "warn",
+            {
+                "allowInPropTypes": true
+            }
+        ],
+        "react/jsx-no-comment-textnodes": "warn",
+        "react/jsx-no-duplicate-props": [
+            "warn",
+            {
+                "ignoreCase": true
+            }
+        ],
+        "react/jsx-no-target-blank": "warn",
+        "react/jsx-no-undef": "error",
+        "react/jsx-pascal-case": [
+            "warn",
+            {
+                "allowAllCaps": true,
+                "ignore": []
+            }
+        ],
+        "react/jsx-uses-react": "warn",
+        "react/jsx-uses-vars": "warn",
+        "react/no-danger-with-children": "warn",
+        "react/no-deprecated": "warn",
+        "react/no-direct-mutation-state": "warn",
+        "react/no-is-mounted": "warn",
+        "react/react-in-jsx-scope": "error",
+        "react/require-render-return": "error",
+        "react/style-prop-object": "warn",
+        "flowtype/define-flow-type": "warn",
+        "flowtype/require-valid-file-annotation": "warn",
+        "flowtype/use-flow-type": "warn",
+        "jsx-a11y/accessible-emoji": "error",
+        "jsx-a11y/alt-text": "error",
+        "jsx-a11y/anchor-has-content": "error",
+        "jsx-a11y/anchor-is-valid": "error",
+        "jsx-a11y/aria-activedescendant-has-tabindex": "error",
+        "jsx-a11y/aria-props": "error",
+        "jsx-a11y/aria-proptypes": "error",
+        "jsx-a11y/aria-role": "error",
+        "jsx-a11y/aria-unsupported-elements": "error",
+        "jsx-a11y/click-events-have-key-events": "error",
+        "jsx-a11y/heading-has-content": "error",
+        "jsx-a11y/html-has-lang": "error",
+        "jsx-a11y/iframe-has-title": "error",
+        "jsx-a11y/img-redundant-alt": "error",
+        "jsx-a11y/interactive-supports-focus": [
+            "error",
+            {
+                "tabbable": [
+                    "button",
+                    "checkbox",
+                    "link",
+                    "searchbox",
+                    "spinbutton",
+                    "switch",
+                    "textbox"
+                ]
+            }
+        ],
+        "jsx-a11y/label-has-associated-control": "error",
+        "jsx-a11y/media-has-caption": "error",
+        "jsx-a11y/mouse-events-have-key-events": "error",
+        "jsx-a11y/no-access-key": "error",
+        "jsx-a11y/no-autofocus": "error",
+        "jsx-a11y/no-distracting-elements": "error",
+
+        "jsx-a11y/no-interactive-element-to-noninteractive-role": [
+            "error",
+            {
+                "tr": ["none", "presentation"]
+            }
+        ],
+        "jsx-a11y/no-noninteractive-element-interactions": [
+            "error",
+            {
+                "handlers": [
+                    "onClick",
+                    "onError",
+                    "onLoad",
+                    "onMouseDown",
+                    "onMouseUp",
+                    "onKeyPress",
+                    "onKeyDown",
+                    "onKeyUp"
+                ],
+                "body": ["onError", "onLoad"],
+                "iframe": ["onError", "onLoad"],
+                "img": ["onError", "onLoad"]
+            }
+        ],
+        "jsx-a11y/no-noninteractive-element-to-interactive-role": [
+            "error",
+            {
+                "ul": [
+                    "listbox",
+                    "menu",
+                    "menubar",
+                    "radiogroup",
+                    "tablist",
+                    "tree",
+                    "treegrid"
+                ],
+                "ol": [
+                    "listbox",
+                    "menu",
+                    "menubar",
+                    "radiogroup",
+                    "tablist",
+                    "tree",
+                    "treegrid"
+                ],
+                "li": ["menuitem", "option", "row", "tab", "treeitem"],
+                "table": ["grid"],
+                "td": ["gridcell"]
+            }
+        ],
+        "jsx-a11y/no-noninteractive-tabindex": [
+            "error",
+            {
+                "tags": [],
+                "roles": ["tabpanel"]
+            }
+        ],
+        "jsx-a11y/no-onchange": "error",
+        "jsx-a11y/no-redundant-roles": "error",
+        "jsx-a11y/no-static-element-interactions": [
+            "error",
+            {
+                "handlers": [
+                    "onClick",
+                    "onMouseDown",
+                    "onMouseUp",
+                    "onKeyPress",
+                    "onKeyDown",
+                    "onKeyUp"
+                ]
+            }
+        ],
+        "jsx-a11y/role-has-required-aria-props": "error",
+        "jsx-a11y/role-supports-aria-props": "error",
+        "jsx-a11y/scope": "error",
+        "jsx-a11y/tabindex-no-positive": "error"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -24,14 +24,17 @@
         "umd"
     ],
     "scripts": {
-        "build": "nwb build-react-component",
+        "build":"npm-run-all lint lint-demo build-app",
+        "build-app": "nwb build-react-component",
         "clean": "nwb clean-module && nwb clean-demo",
         "start": "nwb serve-react-demo",
         "test": "node scripts/test.js --env=jsdom --coverage",
         "watch": "node scripts/test.js --env=jsdom",
         "format-src": "prettier --write src/**/*.js",
-        "format-demo": "prettier --write demo/**/*.js",
-        "format": "npm-run-all format-src format-demo"
+        "format-demo": "prettier --write demo/**/*.js !demo/dist/**",
+        "format": "npm-run-all format-src format-demo",
+        "lint": "eslint *.js src",
+        "lint-demo": "eslint *.js demo"
     },
     "dependencies": {
         "axios": "0.18.0",
@@ -46,11 +49,10 @@
         "babel-jest": "20.0.3",
         "babel-preset-react-app": "^3.1.1",
         "eslint": "4.10.0",
-        "eslint-config-react-app": "^2.1.0",
         "eslint-loader": "1.9.0",
         "eslint-plugin-flowtype": "2.39.1",
         "eslint-plugin-import": "2.8.0",
-        "eslint-plugin-jsx-a11y": "5.1.1",
+        "eslint-plugin-jsx-a11y": "6.1.1",
         "eslint-plugin-react": "7.4.0",
         "jest": "22.1.4",
         "jest-dom": "1.11.0",
@@ -101,8 +103,5 @@
         "presets": [
             "react-app"
         ]
-    },
-    "eslintConfig": {
-        "extends": "react-app"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -218,9 +218,9 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@^0.7.0:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.7.1.tgz#26cbb5aff64144b0a825be1846e0b16cfa00b11e"
+aria-query@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
   dependencies:
     ast-types-flow "0.0.7"
     commander "^2.11.0"
@@ -344,7 +344,7 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
-ast-types-flow@0.0.7:
+ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
 
@@ -429,9 +429,9 @@ axios@^0.15.3:
   dependencies:
     follow-redirects "1.0.0"
 
-axobject-query@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-0.1.0.tgz#62f59dbc59c9f9242759ca349960e7a2fe3c36c0"
+axobject-query@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.1.tgz#05dfa705ada8ad9db993fa6896f22d395b0b0a07"
   dependencies:
     ast-types-flow "0.0.7"
 
@@ -2493,7 +2493,7 @@ d@1:
   dependencies:
     es5-ext "^0.10.9"
 
-damerau-levenshtein@^1.0.0:
+damerau-levenshtein@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz#03191c432cb6eea168bb77f3a55ffdccb8978514"
 
@@ -2885,7 +2885,7 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-emoji-regex@^6.1.0:
+emoji-regex@^6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.5.1.tgz#9baea929b155565c11ea41c6626eaa65cef992c2"
 
@@ -3063,10 +3063,6 @@ escodegen@1.x.x, escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-react-app@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-2.1.0.tgz#23c909f71cbaff76b945b831d2d814b8bde169eb"
-
 eslint-import-resolver-node@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
@@ -3112,17 +3108,18 @@ eslint-plugin-import@2.8.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
-eslint-plugin-jsx-a11y@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.1.1.tgz#5c96bb5186ca14e94db1095ff59b3e2bd94069b1"
+eslint-plugin-jsx-a11y@6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.1.1.tgz#7bf56dbe7d47d811d14dbb3ddff644aa656ce8e1"
   dependencies:
-    aria-query "^0.7.0"
+    aria-query "^3.0.0"
     array-includes "^3.0.3"
-    ast-types-flow "0.0.7"
-    axobject-query "^0.1.0"
-    damerau-levenshtein "^1.0.0"
-    emoji-regex "^6.1.0"
-    jsx-ast-utils "^1.4.0"
+    ast-types-flow "^0.0.7"
+    axobject-query "^2.0.1"
+    damerau-levenshtein "^1.0.4"
+    emoji-regex "^6.5.1"
+    has "^1.0.3"
+    jsx-ast-utils "^2.0.1"
 
 eslint-plugin-react@7.4.0:
   version "7.4.0"
@@ -4047,7 +4044,7 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
-has@^1.0.0, has@^1.0.1:
+has@^1.0.0, has@^1.0.1, has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   dependencies:
@@ -5334,11 +5331,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jsx-ast-utils@^1.4.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
-
-jsx-ast-utils@^2.0.0:
+jsx-ast-utils@^2.0.0, jsx-ast-utils@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
   dependencies:


### PR DESCRIPTION
In the first creation step, ESLINT was neglegted during the build phase. 

In this PR:

1. Activate a full gamut of `eslint-plugin-jsx-a11y` checks.
2. Integrate into the build script.